### PR TITLE
Add a dynamic module register interface and use it to register a new module called "dcdb"

### DIFF
--- a/QcloudApi/modules/__init__.py
+++ b/QcloudApi/modules/__init__.py
@@ -7,9 +7,9 @@ _GLOBAL_MODULES = {}
 def register_module(name, host, path):
     """Register a new module to current modules
 
-    :param name string: module name
-    :param host string: request host
-    :param path string: request path
+    :param name: module name, such as "dcdb"
+    :param host: request host
+    :param path: request path
     """
     mclass = type("DynamicModule_%s" % name, (Base, ), {
         "requestHost": host,
@@ -21,10 +21,9 @@ def register_module(name, host, path):
 def find_module_by_name(name):
     """Find a dynamic module by given module name
 
-    :param name string: module name
+    :param name: module name
     :returns: a DynamicModule class or None if no module named `name` is found
     """
-    print(_GLOBAL_MODULES)
     return _GLOBAL_MODULES.get(name, None)
 
 

--- a/QcloudApi/modules/__init__.py
+++ b/QcloudApi/modules/__init__.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+from .base import Base
+
+_GLOBAL_MODULES = {}
+
+
+def register_module(name, host, path):
+    """Register a new module to current modules
+
+    :param name string: module name
+    :param host string: request host
+    :param path string: request path
+    """
+    mclass = type("DynamicModule_%s" % name, (Base, ), {
+        "requestHost": host,
+        "requestUri": path
+    })
+    _GLOBAL_MODULES[name] = mclass
+
+
+def find_module_by_name(name):
+    """Find a dynamic module by given module name
+
+    :param name string: module name
+    :returns: a DynamicModule class or None if no module named `name` is found
+    """
+    print(_GLOBAL_MODULES)
+    return _GLOBAL_MODULES.get(name, None)
+
+
+# Register current default modules
+# DCDB documentation: https://cloud.tencent.com/document/product/557/16123
+register_module("dcdb", "dcdb.tencentcloudapi.com", "/")

--- a/QcloudApi/qcloudapi.py
+++ b/QcloudApi/qcloudapi.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python
 # -*- coding: utf-8 -*-
+from .modules import find_module_by_name
 
 
 class QcloudApi(object):
@@ -8,6 +9,11 @@ class QcloudApi(object):
         self.config = config
 
     def _factory(self, module, config):
+        # Try to find a dynamic module first
+        dynamic_module = find_module_by_name(module)
+        if dynamic_module:
+            return dynamic_module(config)
+
         if (module == 'cdb'):
             from .modules.cdb import Cdb
             service = Cdb(config)

--- a/README.md
+++ b/README.md
@@ -103,3 +103,20 @@ qcloudapi-sdk-python是为了让Python开发者能够在自己的代码里更快
     except Exception as e:
         import traceback
         print('traceback.format_exc():\n%s' % traceback.format_exc())
+
+#### 其他帮助
+
+##### 如何调用 SDK 目前不支持的模块 API
+
+如果在使用过程中，发现需要调用的腾讯云产品 API 还没有被当前 SDK 版本支持，你可以通过调用特殊函数 `register_module` 来动态注册新模块，完成调用。
+
+```python
+# 一个注册 dcdb 模块的示例
+from QcloudApi.modules import register_module
+
+
+register_module("dcdb", host="dcdb.tencentcloudapi.com", path="/")
+
+service = QcloudApi("dcdb", {... ...})
+service.call(... ...)
+```


### PR DESCRIPTION
- Added a dynamic module register interface to simplify the process of adding new module which only defines a different request host and path.
- Use this interface to register dcdb module(https://cloud.tencent.com/document/product/557/16123)
- Added the usage of `register_module()` function to README

We could also consider migrating current implementation of other modules which only defines a host and path to current dynamic interface in order to reduce complexity.

Thank you.
